### PR TITLE
Add php7 bcmath for more compatibility with Drupal contrib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ apk --no-cache --update add \
     php7-ctype \
     php7-gd \
     php7-dom \
+    php7-bcmath \
     php7-gmagick && \
 rm -rf /tmp/* && \
 rm -rf /var/cache/apk/*


### PR DESCRIPTION
solves https://github.com/wunderkraut/alpine-php/issues/7

This patch adds php7 bcmath module, which is a requirement for sevaral common Drupal contrib projects, and is used in a few Wunder client projects as well.
