### PR TITLE
Feature/#18 update base to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ MAINTAINER james.nesbitt@wunder.io
 ####
 # Install php7 packages from edge repositories
 #
-RUN apk --no-cache --update add \
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    apk --no-cache --update add \
         php7-fpm \
         php7-apcu \
         php7-common \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,7 @@ MAINTAINER james.nesbitt@wunder.io
 ####
 # Install php7 packages from edge repositories
 #
-RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
-    echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
-    echo http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
-    apk --no-cache --update add \
+RUN apk --no-cache --update add \
         php7-fpm \
         php7-apcu \
         php7-common \


### PR DESCRIPTION
There are issues in the child images when using edge repositories with 3.6, but we still need edge/testing for php7-gmagick so we should include that and remove the others. Successful build tested all the way down to the devshell image here https://quay.io/repository/wunder/fuzzy-alpine-devshell/build/724817c9-ade0-4bb0-9619-d58e09a6cc9b with `v7.1.5-0-pre6` tag.